### PR TITLE
Check if hotServer is url

### DIFF
--- a/src/LaravelViteHelper.php
+++ b/src/LaravelViteHelper.php
@@ -24,9 +24,7 @@ class LaravelViteHelper
      */
     public function resourceUrl($resourcePath, $buildDirectory = 'build', $relative = false, $hotServer = true)
     {
-        $hotServerUrl = $this->hotServer();
-
-        if ($hotServer && str($hotServerUrl)->isUrl()) {
+        if ($hotServer && ($server = $this->hotServer())) {
             return "{$hotServerUrl}/{$resourcePath}";
         }
 

--- a/src/LaravelViteHelper.php
+++ b/src/LaravelViteHelper.php
@@ -24,8 +24,10 @@ class LaravelViteHelper
      */
     public function resourceUrl($resourcePath, $buildDirectory = 'build', $relative = false, $hotServer = true)
     {
-        if ($hotServer && $server = $this->hotServer()) {
-            return "$server/$resourcePath";
+        $hotServerUrl = $this->hotServer();
+
+        if ($hotServer && str($hotServerUrl)->isUrl()) {
+            return "{$hotServerUrl}/{$resourcePath}";
         }
 
         $manifest = $this->manifestContents($buildDirectory);

--- a/src/LaravelViteHelper.php
+++ b/src/LaravelViteHelper.php
@@ -25,7 +25,7 @@ class LaravelViteHelper
     public function resourceUrl($resourcePath, $buildDirectory = 'build', $relative = false, $hotServer = true)
     {
         if ($hotServer && ($server = $this->hotServer())) {
-            return "{$hotServerUrl}/{$resourcePath}";
+            return "$server/$resourcePath";
         }
 
         $manifest = $this->manifestContents($buildDirectory);

--- a/tests/ViteHelperTest.php
+++ b/tests/ViteHelperTest.php
@@ -41,6 +41,16 @@ class ViteHelperTest extends TestCase
         $this->assertEquals('http://localhost:3000/resources/css/app.css', $result);
     }
 
+    public function testViteForcdBuildServerUrl()
+    {
+        $this->makeViteHotFile();
+        $this->makeViteManifest();
+
+        $result = (new LaravelViteHelper)->resourceUrl('resources/css/app.css', hotServer: false);
+
+        $this->assertEquals('https://example.com/build/assets/app.versioned.css', $result);
+    }
+
     public function testViteBuildSingleFileManifestResolution()
     {
         $this->makeViteManifest();


### PR DESCRIPTION
We notice something like this didn't work, when running `npm run dev`:
```php
href="{{ public_path(vite('resources/css/mail.css', 'build', true, false)) }}"
```
Note we did run `npm run build` before, and forcing not to use the hot-server.

I don't know why, but removing `if ($server = $this->hotServer()` out of the statement fixed the issue.

Anyway, I've also added a check to make sure the hotserver is actually an url.