### PR TITLE
Fixed incompatible declaration in Vite mock helper

### DIFF
--- a/src/Traits/MocksViteHelper.php
+++ b/src/Traits/MocksViteHelper.php
@@ -18,7 +18,7 @@ trait MocksViteHelper
         }
 
         app()->instance(LaravelViteHelper::class, new class () extends LaravelViteHelper {
-            public function resourceUrl($resourcePath, $buildDirectory = 'build', $relative = false)
+            public function resourceUrl($resourcePath, $buildDirectory = 'build', $relative = false, $hotServer = true)
             {
                 return '';
             }


### PR DESCRIPTION
Made declaration of resourceUrl within MocksViteHelper the same as the helper itself